### PR TITLE
Inline `AncestralSequence::mlCharProbAt` and `AncestralSequence::mlCharProbAtF` methods

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@
 
 CC            = gcc
 CXX           = g++
-DEFINES       = 
+DEFINES       = -DNDEBUG
 CFLAGS        = -m64 -pipe -O3 $(DEFINES)
 CXXFLAGS      = -m64 -pipe -O3 $(DEFINES)
 INCPATH       = -I. -I/usr/include

--- a/src/ancestralsequence.cpp
+++ b/src/ancestralsequence.cpp
@@ -574,23 +574,6 @@ void AncestralSequence::cleanSpace()
 }
 
 
-// Get the probability of characters in different structures given the tree.
-// Takes into account the phylogeny.
-//
-double AncestralSequence::mlCharProbAt(int j,int i,int k)
-{
-    return mlCharProb->g(k,j,i);
-}
-
-// Same for insertions skipped
-//
-double AncestralSequence::mlCharProbAtF(int j,int i,int k)
-{
-    realIndex->g(i);
-
-    return mlCharProb->g(k,j,realIndex->g(i));
-}
-
 void AncestralSequence::writeSequence(string name)
 {
     char str[10];

--- a/src/ancestralsequence.h
+++ b/src/ancestralsequence.h
@@ -177,9 +177,20 @@ public:
     void setChildGaps(Sequence *l,Sequence *r);
     void setRealIndex(bool left);
 
-    double mlCharProbAt(int j,int i,int k);
-    double mlCharProbAtF(int j,int i,int k);
+    // Get the probability of characters in different structures given the tree.
+    // Takes into account the phylogeny.
+    //
+    double mlCharProbAt(int j,int i,int k)
+    {
+        return mlCharProb->g(k,j,i);
+    }
 
+    // Same for insertions skipped
+    //
+    double mlCharProbAtF(int j,int i,int k)
+    {
+        return mlCharProb->g(k,j,realIndex->g(i));
+    }
 
     void cleanSpace();
 

--- a/src/boolmatrix.h
+++ b/src/boolmatrix.h
@@ -58,8 +58,8 @@ public:
     void initialise(int v = 0);
 
     int g(int xa, int ya=0, int za = 0, int wa = 0)
-    { /**/
-        if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;/**/
+    {
+        /*if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;*/
         assert(xa>=0);
         assert(xa<x);
         assert(ya>=0);

--- a/src/dbmatrix.h
+++ b/src/dbmatrix.h
@@ -61,8 +61,8 @@ public:
     void initialise(double v = 0);
 
     double g(int xa, int ya=0, int za = 0, int wa = 0)
-    { /**/
-        if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;/**/
+    {
+        /* if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl; */
         assert(xa>=0);
         assert(xa<x);
         assert(ya>=0);

--- a/src/dbmatrix.h
+++ b/src/dbmatrix.h
@@ -20,8 +20,6 @@
 #ifndef DBMATRIX_H
 #define DBMATRIX_H
 
-#define NDEBUG
-
 #ifndef RFOR
 #define RFOR(i,n) for(i=n; i>=0; i--)
 #endif

--- a/src/flmatrix.h
+++ b/src/flmatrix.h
@@ -61,8 +61,8 @@ public:
     void initialise(float v = 0);
 
     float g(int xa, int ya=0, int za = 0, int wa = 0)
-    { /**/
-        if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;/**/
+    {
+        /*if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;*/
         assert(xa>=0);
         assert(xa<x);
         assert(ya>=0);

--- a/src/flmatrix.h
+++ b/src/flmatrix.h
@@ -20,8 +20,6 @@
 #ifndef FLMATRIX_H
 #define FLMATRIX_H
 
-// #define NDEBUG
-
 #ifndef RFOR
 #define RFOR(i,n) for(i=n; i>=0; i--)
 #endif

--- a/src/intmatrix.h
+++ b/src/intmatrix.h
@@ -20,8 +20,6 @@
 #ifndef INTMATRIX_H
 #define INTMATRIX_H
 
-// #define NDEBUG
-
 #ifndef RFOR
 #define RFOR(i,n) for(i=n; i>=0; i--)
 #endif

--- a/src/intmatrix.h
+++ b/src/intmatrix.h
@@ -60,8 +60,8 @@ public:
     void initialise(int v = 0);
 
     int g(int xa, int ya=0, int za = 0, int wa = 0)
-    { /**/
-        if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;/**/
+    {
+        /*if (!(xa>=0&&ya>=0&&za>=0&&wa>=0&&xa<x&&ya<y&&za<z&&wa<w))std::cout<<name<<" "<<xa<<" "<<ya<<" "<<za<<" "<<wa<<std::endl;*/
         assert(xa>=0);
         assert(xa<x);
         assert(ya>=0);


### PR DESCRIPTION
Hi Ari!

I was exploring the PRANK code and doing some profiling to see if I could make it any faster. After profiling with Valgrind, I found that the `AncestralSequence::mlCharProbAt` was in a very hot path: on my example of 12 sequences, it was being called 3M times, with a total cycle count of 150M cycles, out of a total execution of 400M cycles.

However, all this function is doing is loading data from memory, so it's not really normal to take 50 cycles per fetch; besides, hiding it in a function prevents the CPU from pipelining load instructions when used inside of a loop. By inlining this one function, the same invokation of PRANK went from 400M cycles to 250M cycles.

In terms of timing, that's how it improved on my machine:
![image](https://user-images.githubusercontent.com/8660647/172835099-d1df9b9e-0fe7-475c-8ace-6374ac7debc6.png)
