### PR TITLE
fix: traverse post- instead of in-order for approximate ancestral sequence

### DIFF
--- a/src/ancestralnode.h
+++ b/src/ancestralnode.h
@@ -21,8 +21,8 @@
 #ifndef ANCESTRALNODE_H
 #define ANCESTRALNODE_H
 
-#include <treenode.h>
-#include <ancestralsequence.h>
+#include "treenode.h"
+#include "ancestralsequence.h"
 
 class AncestralNode : public TreeNode
 {
@@ -112,14 +112,13 @@ public:
     void setPermanentInsertion(int i);
     void printChildAlignment(TreeNode *node,std::string filename);
 
-    void setAncSequenceStrings(std::vector<std::string> *aseqs)
+    void setAncSequenceStrings(std::vector<std::string>::iterator &aseqs)
     {
         lChild->setAncSequenceStrings(aseqs);
-
-        alignedseqstr = aseqs->at(0);
-        aseqs->erase(aseqs->begin());
-
         rChild->setAncSequenceStrings(aseqs);
+
+        alignedseqstr = *aseqs;
+        ++aseqs;
     }
 
     void setAncSequenceStrings(std::map<std::string,std::string> *aseqs)

--- a/src/progressivealignment.cpp
+++ b/src/progressivealignment.cpp
@@ -907,9 +907,9 @@ void ProgressiveAlignment::reconstructAncestors(AncestralNode *root,bool isDna)
     vector<string> aseqs;
     this->getAncestralAlignmentMatrix(root,&aseqs);
 
-    root->getLChild()->setAncSequenceStrings(&aseqs);
-    root->setThisAncSequenceString(&aseqs);
-    root->getRChild()->setAncSequenceStrings(&aseqs);
+    auto it = aseqs.begin();
+    // recurses the tree in post-order
+    root->setAncSequenceStrings(it);
 }
 
 void ProgressiveAlignment::setAlignedSequences(AncestralNode *root)

--- a/src/terminalnode.h
+++ b/src/terminalnode.h
@@ -95,7 +95,7 @@ public:
     void getIndelEvents(std::vector<indelEvent> *indels){}
     void getSubstEvents(std::vector<substEvent> *substs){}
 
-    void setAncSequenceStrings(std::vector<std::string>*){}
+    void setAncSequenceStrings(std::vector<std::string>::iterator&){}
     void getAncSequenceStrings(std::vector<std::string>*){}
 
     void setAncSequenceGaps(std::vector<std::string>*){}

--- a/src/treenode.h
+++ b/src/treenode.h
@@ -283,7 +283,7 @@ public:
     virtual void getMLAncestralSeqs(std::vector<std::string>* ,std::vector<std::string>* ) {}
 
     virtual void setPermanentInsertion(int ) {}
-    virtual void setAncSequenceStrings(std::vector<std::string>*){}
+    virtual void setAncSequenceStrings(std::vector<std::string>::iterator&){}
     virtual void setAncSequenceStrings(std::map<std::string,std::string>*){}
     virtual void getAncSequenceStrings(std::vector<std::string>*){}
     virtual void setAlignedSequenceStrings(std::vector<std::string>*){}


### PR DESCRIPTION
This should fix #26 and also relates to #16. The issue was that an in-order traversal was executed when it should have been post-order.

The problem only shows up if neither RaXML nor BppAncestor is found and used to infer the ancestral sequences. Then, PRANK uses an "approximate" method, which had this bug.