### PR TITLE
fix: -version reports a 404 page as "Found updates" and prints its HTML

### DIFF
--- a/src/check_version.cpp
+++ b/src/check_version.cpp
@@ -17,7 +17,7 @@ using namespace std;
 Check_version::Check_version(int version)
 {
 
-    cout<<"\nThis is PRANK v."<<version<<".\nChecking if updates are available at http://http://code.google.com/p/prank-msa.\n";
+    cout<<"\nThis is PRANK v."<<version<<".\nChecking if updates are available at https://github.com/ariloytynoja/prank-msa.\n";
 
     struct sockaddr_in *remote;
     char buf[BUFSIZ+1];
@@ -68,10 +68,21 @@ Check_version::Check_version(int version)
     memset(buf, 0, sizeof(buf));
     int htmlstart = 0;
     char * htmlcontent;
+    // The status line arrives at the head of the first chunk.  It has to be
+    // checked: the endpoint below no longer serves this file, and an error
+    // page parsed as a changelog is reported to the user as "Found updates".
+    string status_line;
+    bool  status_seen = false;
     while ((tmpres = recv(sock, buf, BUFSIZ, 0)) > 0)
     {
         if (htmlstart == 0)
         {
+            if (!status_seen)
+            {
+                status_seen = true;
+                const char *eol = strstr(buf, "\r\n");
+                status_line.assign(buf, eol ? (size_t)(eol - buf) : strlen(buf));
+            }
             /* Under certain conditions this will not work.
             * If the \r\n\r\n part is splitted into two messages
             * it will fail to detect the beginning of HTML content
@@ -97,6 +108,20 @@ Check_version::Check_version(int version)
     if (tmpres < 0)
     {
         perror("Error receiving data");
+    }
+
+    // Anything other than 200 means we did not get the version file.  Say so,
+    // rather than parsing the error page and announcing imaginary updates.
+    if (status_line.find(" 200") == string::npos)
+    {
+        cout<<"\nCould not check for updates";
+        if (!status_line.empty())
+            cout<<" (server said: "<<status_line<<")";
+        cout<<".\n\n";
+        free(remote);
+        free(ip);
+        close(sock);
+        return;
     }
 
     bool print_this = true;


### PR DESCRIPTION
# `-version` reports a 404 page as "Found updates" and prints its HTML

## Symptom

On today's `master`, `prank -version` announces updates that do not exist and
dumps a Google error page onto stdout:

```
This is PRANK v.250331.
Checking if updates are available at http://http://code.google.com/p/prank-msa.

Found updates. Changes in the more recent versions:

<!DOCTYPE html>
<html lang=en>
  <title>Error 404 (Not Found)!!1</title>
...
  <p><b>404.</b> <ins>That's an error.</ins>
  <p>The requested URL <code>/git/VERSION_HISTORY</code> was not found on this server.
```

## Three problems

**1. The endpoint is gone.** `Check_version` fetches
`prank-msa.googlecode.com/git/VERSION_HISTORY`. Google Code shut down in 2016.
The hostname still resolves — it lands on a Google wildcard — so the connection
*succeeds* and returns a 404 page instead of failing outright. That is what
makes this non-obvious: nothing errors.

**2. The HTTP status is never checked**, so the body is parsed as a changelog
whatever comes back. The parser marks a line as "already known" only when it
matches `v.<number>`; an HTML error page contains no such line, so *every* line
counts as newer than the running version. The result is the update banner
followed by the entire page. A dead endpoint therefore produces a confident
false positive rather than a visible failure.

**3. The printed URL has a doubled scheme** — `http://http://code.google.com/…`
— and points at the dead project page.

## This patch

Captures the HTTP status line and refuses to parse a non-200 response:

```
This is PRANK v.250331.
Checking if updates are available at https://github.com/ariloytynoja/prank-msa.

Could not check for updates (server said: HTTP/1.0 404 Not Found).
```

Exit status is unchanged (0), and nothing outside `-version` is touched —
`Check_version` is constructed only in the `-version` branch of `prank.cpp`.

## Deliberately not addressed

Pointing the fetch at a live source. The current code speaks plain HTTP on
port 80 through a raw socket, and the natural replacement
(`raw.githubusercontent.com`) is HTTPS-only, so it needs TLS. PAGAN2 solves the
same problem with libcurl, which PRANK does not currently link — that is a
larger change and your call to make. Until then this at least fails honestly
instead of inventing a changelog.

Happy to follow up with the libcurl version if you would like it, or to drop
the URL text change if you would rather keep the project page pointing
elsewhere.
