### PR TITLE
fix: PwHirschberg::rndBool() uses integer division, so it never returns true

### DIFF
--- a/src/pwhirschberg.cpp
+++ b/src/pwhirschberg.cpp
@@ -957,7 +957,7 @@ void PwHirschberg::getMidSite(int s1,int e1,int s2,int e2)
 
 bool PwHirschberg::rndBool()
 {
-    int p = (int)rand()/(int)RAND_MAX;
+    double p = (double)rand()/(double)RAND_MAX;
     if (p>0.5)
         return true;
     else


### PR DESCRIPTION
`PwHirschberg::rndBool()` is meant to flip a fair coin to break an exact tie in
the pairwise Viterbi used for guide-tree distances. It cannot:

    int p = (int)rand()/(int)RAND_MAX;    // both operands int -> INTEGER division
    if (p>0.5)                            // int compared against a double
        return true;
    return false;

`rand()` returns `0 .. RAND_MAX`, so `(int)rand()/(int)RAND_MAX` evaluates to `0`
for every draw except the single value `rand() == RAND_MAX`, which gives `1`.
`p > 0.5` is therefore false with probability `1 - 1/(RAND_MAX+1)`, about
`1 - 4.7e-10` on glibc. The coin lands the same way every time.

Its two sibling implementations already do this correctly, which is the clearest
evidence that the intent is a double division and this copy simply drifted:

    src/hirschberg.cpp:3809     double p = (double)rand()/(double)RAND_MAX;
    src/readalignment.cpp:1203  double p = (double)rand()/(double)RAND_MAX;

Both are otherwise identical to this function. `PwHirschberg::rndInt()`, three
lines below, is also correct -- `(int)(i*(rand()/(RAND_MAX+1.0)))` -- so the
integer division here is isolated.

Effect: at `PwHirschberg::max(int,int)` an exact score tie always resolves to
the second argument rather than to either at random. That is a bias in
guide-tree distance estimation, not in the reported alignment, so it is quiet --
which is presumably why it has survived.

Worth stating plainly for whoever applies this: on its own, this makes PRANK
slightly MORE variable run to run, because it activates a tie-break that is
currently inert. Reproducibility is a separate matter -- `srand(time(0))` at
`src/prank.cpp:835` when no `-seed` is given -- and is addressed separately.

Verified: builds clean, and `prank -version` still reports.


