### PR TITLE
fix: -reproducible was not reproducible, and was undocumented

### DIFF
--- a/src/prank.cpp
+++ b/src/prank.cpp
@@ -820,6 +820,18 @@ void readArguments(int argc, char *argv[])
         exit(0);
     }
 
+    // -reproducible asks for a repeatable run, so it needs a repeatable seed.
+    // Without one it reseeds from Hirschberg's constructor default, which is
+    // time(NULL) -- constant within a run, different on the next one -- so the
+    // flag reseeded diligently to a value that still varied and the run was not
+    // reproducible. Supplying a fixed default here also switches on the
+    // deterministic per-node seeding already present in
+    // AncestralNode::alignSequences (gated on rnd_seed>0), which derives each
+    // node's seed from a hash of its terminal names and is therefore
+    // independent of node visit order. An explicit -seed=# still wins.
+    if (REPRODUCIBLE && rnd_seed<=0)
+        rnd_seed = 1;
+
     // define a seed for random numbers
     if (rnd_seed>0)
         srand(rnd_seed);
@@ -912,7 +924,8 @@ void printHelp(bool complete)
         cout<<"  -fixedbranches=# [use fixed branch lengths]"<<endl;
         cout<<"  -maxbranches=# [set maximum branch length]"<<endl;
         cout<<"  -realbranches [disable branch length truncation]"<<endl;
-        cout<<"  -seed=# [set random number seed]"<<endl;
+        cout<<"  -seed=# [set random number seed; without it the seed comes from the clock]"<<endl;
+        cout<<"  -reproducible [repeatable output: implies a fixed seed unless -seed=# is given]"<<endl;
     }
     cout<<"  -translate [translate to protein]"<<endl;
     cout<<"  -mttranslate [translate to protein using mt table]"<<endl;


### PR DESCRIPTION
`-reproducible` (src/prank.cpp:562) exists to make a run repeatable, and the
plumbing for it is already in place: `Hirschberg::rndBool`/`rndInt` and
`ReadAlignment::rndBool`/`rndInt` all reseed from `random_seed` before every
draw when the flag is set. But nothing gives `random_seed` a repeatable value.

`Hirschberg`'s constructor sets it from the clock:

    src/hirschberg.cpp:152    random_seed = (unsigned)time(NULL);

and `AncestralNode::alignSequences` only overrides that with a deterministic,
name-derived seed when a seed was explicitly requested:

    src/ancestralnode.cpp:292    if (rnd_seed>0)
    src/ancestralnode.cpp:296        unsigned int rs = this->hash(catNames.c_str());
    src/ancestralnode.cpp:298        hp->setRandomSeed(rs);

Since `rnd_seed` defaults to `-1` (src/prank.h:172), `-reproducible` alone
reseeds conscientiously to a value that is constant WITHIN a run and different
on the NEXT one. The flag therefore did not deliver what its name promises, and
the failure is silent -- output looks stable if you only run it once.

Fixed by giving `-reproducible` a fixed default seed when none was requested,
which also switches on the existing per-node hash seeding above. That mechanism
is the better half of this: because each node's seed derives from a hash of its
own terminal names, the result does not depend on the order nodes are visited.
An explicit `-seed=#` still takes precedence.

`-reproducible` was also absent from `-help` entirely -- it appears exactly once
in the source, at the point where it is parsed -- so there was no way to
discover it. Both it and `-seed=#`'s default behaviour are now documented.

MEASURED, on a 3882-column pairwise codon alignment of a SARS-CoV-2 spike read
against its reference (PRANK v.250331, one invocation per run, `-F -once
-codon`):

    no flags        14 runs -> 7 DISTINCT alignments (matched columns 3690..3693)
    -seed=1          6 runs -> 1
    -seed=2          3 runs -> 1, and a different alignment from -seed=1

The variance is entirely tie-breaking: `pwhirschberg.cpp:748` picks among
equal-scoring DP cells with `rndInt(maxCell.size())`, and `max(a,b)` at :988
picks randomly when `a == b`. Nothing chooses between alignments of different
score -- so the alternatives are equal under PRANK's own objective and only the
choice among equals varied.

For anyone hitting this from downstream: `-seed=#` is the workaround on an
unpatched build. Exonerate anchoring is NOT the cause -- `-noanchors` makes
stability worse and costs about 2x wall time, and with anchors off the seed
still changes the result.

Verified: builds clean; `-reproducible` now yields byte-identical output across
repeated runs on the same input; runs without either flag are unchanged.



