### PR TITLE
fix: an impossible Hirschberg state is reported but not acted on

### DIFF
--- a/src/hirschberg.cpp
+++ b/src/hirschberg.cpp
@@ -744,7 +744,12 @@ void Hirschberg::divideSeq()
             fwdzM->s(beg->vitf(),beg->vitfS());
         else
         {
-            cout<<"hirschberg initialisation: impossible fwd state '"<<beg->vitfM()<<"'"<<endl;
+            cout<<"hirschberg initialisation: impossible fwd state '"<<beg->vitfM()<<"'"
+                <<" at site "<<beg->index()<<" (seq1 "<<beg->cInd1()<<", seq2 "<<beg->cInd2()<<")"<<endl;
+            cout<<"No forward matrix was initialised for this state, so continuing would"
+                <<" align using uninitialised values. Please report this input and command"
+                <<" line at https://github.com/ariloytynoja/prank-msa/issues"<<endl;
+            exit(-1);
         }
     }
 
@@ -851,7 +856,12 @@ void Hirschberg::divideSeq()
             bwdzM->s(end->vitb(),end->vitbS());
         else
         {
-            cout<<"hirschberg initialisation: impossible bwd state '"<<end->vitbM()<<"'"<<endl;
+            cout<<"hirschberg initialisation: impossible bwd state '"<<end->vitbM()<<"'"
+                <<" at site "<<end->index()<<" (seq1 "<<end->cInd1()<<", seq2 "<<end->cInd2()<<")"<<endl;
+            cout<<"No backward matrix was initialised for this state, so continuing would"
+                <<" align using uninitialised values. Please report this input and command"
+                <<" line at https://github.com/ariloytynoja/prank-msa/issues"<<endl;
+            exit(-1);
         }
     }
 


### PR DESCRIPTION
Both dispatch chains in `Hirschberg::divideSeq()` end in an `else` that reports an
impossible Viterbi state and then carries on:

```cpp
else
{
    cout<<"hirschberg initialisation: impossible bwd state '"<<end->vitbM()<<"'"<<endl;
}
}

getMidSite(beg->lInd1(),end->rInd1(),beg->lInd2(),end->rInd2());
```

No matrix has been seeded on that path, so `getMidSite()` and the recursion below
it read values that were never written. `src/hirschberg.cpp:747` (fwd) and `:854`
(bwd) are exact mirrors and both behave this way.

### Nothing reaching that branch is recoverable

* The 11 handled values (0,1,2,3,5,7,8,9,11,13,14) are exactly the states whose
  matrices exist. States are formed as `l*15 + {0,3,6,9,12} + maxIndex` with
  `maxIndex` in 0..2, so 4, 6, 10 and 12 are also in range — but they would name
  `bwdxY`, `bwdyX`, `bwdwY` and `bwdzX`, and no such matrices are declared. The
  four omissions from the chain are deliberate.
* `-1` is the "not set" sentinel written by `defineBegin()`, `defineSite()`,
  `defineESite()` and `defineEnd()`. The first three are caught earlier by the
  `index()==1` and `isAnchor()` branches, so a `-1` arriving here is a site the
  recursion never assigned a state to.

### Where it actually ends up

Confirmed under gdb rather than inferred:

```
#3  std::vector<Cell>::at(unsigned long)
#4  Hirschberg::getMidSite(int, int, int, int)
#5  Hirschberg::divideSeq()
#6..#9 Hirschberg::divideSeq()          (recursion)
#10 Hirschberg::alignSeqs(Sequence*, Sequence*, PhyloMatchScore*)
#11 AncestralNode::alignThisNode()
```

`getMidSite()` collects candidate cells and then picks one:

```cpp
src/hirschberg.cpp:3575    int ms = maxCell.size();
src/hirschberg.cpp:3576    int rc = 0;
src/hirschberg.cpp:3577    if (ms>1)
...
src/hirschberg.cpp:3586    Cell c = maxCell.at(rc);
```

The guard is `ms > 1`, so `ms == 0` is not covered. With no candidate pushed —
which is what an unseeded matrix yields — `rc` stays `0` and `maxCell.at(0)`
throws. That is the whole distance between the printed message and the abort
users actually see. An `ms == 0` check at `:3586` would be a sensible separate
hardening patch; this PR only stops the fall-through that gets there.

### Demonstration

On a 5-sequence codon alignment, forcing one interior site's bwd state to `-1`.
Unpatched:

```
hirschberg initialisation: impossible bwd state '-1'      (x3, from the recursion)
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
Aborted, exit 134
```

Patched:

```
hirschberg initialisation: impossible bwd state '-1' at site 2 (seq1 23, seq2 23)
No backward matrix was initialised for this state, so continuing would align using uninitialised values. Please report this input and command line at https://github.com/ariloytynoja/prank-msa/issues
exit 255
```

Inert otherwise: `-codon`, `-DNA` and `-codon -noanchors` runs of the same file
give byte-identical `.best.fas` before and after, exit 0.

### Consistent with existing handling

`ReadAlignment::computeAlignment()` already treats the analogous condition as
fatal, so this patch is applying the codebase's own convention rather than
introducing one:

```cpp
src/readalignment.cpp:800  cout<<"impossible pointer "<<move<<endl;
src/readalignment.cpp:801  exit(-1);
```

### Relation to #11

Refs #11 — offered as a **possible** contribution to it, not a claimed fix.

The unpatched output above reproduces that issue's reported error text character
for character, including `__n (which is 0) >= this->size() (which is 0)`, so the
fall-through is at least *a* route to the crash people report there. What this
patch does **not** establish is *why* a real input leaves a site without a state
in the first place — I reached the branch by forcing it. So the remaining
question in #11 is upstream of this patch; what changes is that a reporter would
get the state value and the site coordinates instead of an `std::out_of_range`
that points away from the site that failed.

Two things from that thread worth separating, since it has collected more than
one problem over eleven years:

* The nuc-vs-aa detection bug (the `-protein` workaround) was fixed in 2f664ef
  (2025-03-31). That is a different failure from the codon-mode report later in
  the thread, where `-codon` is explicit.
* `src/hirschberg.cpp` has not been modified since ae9c299 (2017-07-03), and
  that commit was thread-safety and stdout changes. The reporters used v.140603
  and v.170427; this dispatch logic is identical in all of them and on master
  today, so nothing has landed that would have changed this behaviour. Anyone
  still hitting it on v.170427 should retest on v.251117 first, since the
  2025-03-31 merge and the later fixes are not in a 2017 build.

### Trade-off

If any input currently reaches this branch and still runs to completion, it will
now stop instead. That output was computed from matrices that were never seeded,
so stopping is the intent — but it is a behaviour change, not only a diagnostic
one, and worth your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
