### PR TITLE
fix: FastTree is unusable — the probe can hang, detection is gated on one hard-coded host, and the executable name is hard-coded

### DIFF
--- a/src/bppancestors.cpp
+++ b/src/bppancestors.cpp
@@ -51,7 +51,7 @@ bool BppAncestors::testExecutable()
     if (epath.find("/")!=std::string::npos)
         epath = epath.substr(0,epath.rfind("/")+1);
     bppdistpath = epath;
-    epath = epath+"bppancestor >/dev/null 2>/dev/null";
+    epath = epath+"bppancestor </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     return WEXITSTATUS(status) == 0;
@@ -78,14 +78,14 @@ bool BppAncestors::testExecutable()
     #endif
 
     bppdistpath = epath;
-    epath = epath+"bppancestor >/dev/null 2>/dev/null";
+    epath = epath+"bppancestor </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     if(WEXITSTATUS(status) == 0)
         return true;
 
     bppdistpath = "";
-    status = system("bppancestor >/dev/null 2>/dev/null");
+    status = system("bppancestor </dev/null >/dev/null 2>/dev/null");
 
     return WEXITSTATUS(status) == 0;
 

--- a/src/config.h
+++ b/src/config.h
@@ -46,6 +46,7 @@ extern string outfile;
 extern string tempdir;
 extern string mafftpath;
 extern string exoneratepath;
+extern string fasttreeexec;
 
 extern string hmmname;
 extern HMModel *hmm;

--- a/src/exonerate_reads.cpp
+++ b/src/exonerate_reads.cpp
@@ -62,7 +62,7 @@ bool Exonerate_reads::test_executable()
         #endif
         
         exoneratepath = epath;
-        epath = epath+"exonerate >/dev/null 2>/dev/null";
+        epath = epath+"exonerate </dev/null >/dev/null 2>/dev/null";
 
         status = system(epath.c_str());
     }
@@ -75,7 +75,7 @@ bool Exonerate_reads::test_executable()
     }
 
     exoneratepath = "";
-    status = system("`exonerate  >/dev/null 2>/dev/null`");
+    status = system("`exonerate  </dev/null >/dev/null 2>/dev/null`");
 
     if(WEXITSTATUS(status) == 1 && NOISE>0)
         cout<<"Using Exonerate to anchor alignments. Use option '-noanchors' to disable.\n";

--- a/src/fasttree_tree.cpp
+++ b/src/fasttree_tree.cpp
@@ -76,24 +76,35 @@ bool FastTree_tree::test_executable()
 
     #endif
 
-    char hostname[1024];
-    hostname[1023] = '\0';
-    gethostname(hostname, 1023);
-
+    // Probe with `-help`, which exits 0.
+    //
+    // Run with no arguments FastTree prints its usage and exits *1*, so the
+    // `WEXITSTATUS(status) == 0` test below could never succeed for it and
+    // FastTree read as absent on every machine. The two
+    // `WEXITSTATUS(status) == 1 && strcmp(hostname, "wasabi2") == 0` clauses
+    // that used to sit here accepted the real exit status, but only on one
+    // named host, so everywhere else this function returned false and prank
+    // silently fell back to its own guide tree.
+    //
+    // `-help` is documented ("run FastTree without any arguments or with the
+    // -help option") and exits 0, so the existing predicate becomes correct
+    // and the hostname special case is no longer needed.
+    //
+    // Measured: FastTree 2.1.11 and 2.2.0 both exit 1 with no arguments;
+    // 2.1.11 exits 0 for `-help`. A version whose `-help` did not exit 0
+    // would simply read as absent, i.e. today's behaviour, so this cannot
+    // regress a working setup.
+    //
+    // stdin stays redirected: harmless here since `-help` returns before
+    // reading input, and it keeps every probe in this file consistent.
     progpath = epath;
-    epath = epath+"fasttree </dev/null >/dev/null 2>/dev/null";
+    epath = epath+"fasttree -help </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
     if(WEXITSTATUS(status) == 0)
         return true;
 
-    if(WEXITSTATUS(status) == 1 && strcmp(hostname, "wasabi2")==0)
-        return true;
-
     progpath = "";
-    status = system("fasttree </dev/null >/dev/null 2>/dev/null");
-
-    if(WEXITSTATUS(status) == 1 && strcmp(hostname, "wasabi2")==0)
-        return true;
+    status = system("fasttree -help </dev/null >/dev/null 2>/dev/null");
 
     return WEXITSTATUS(status) == 0;
 

--- a/src/fasttree_tree.cpp
+++ b/src/fasttree_tree.cpp
@@ -50,7 +50,7 @@ bool FastTree_tree::test_executable()
     if (epath.find("/")!=std::string::npos)
         epath = epath.substr(0,epath.rfind("/")+1);
     progpath = epath;
-    epath = epath+"fasttree >/dev/null 2>/dev/null";
+    epath = epath+"fasttree </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     return WEXITSTATUS(status) == 0;
@@ -81,7 +81,7 @@ bool FastTree_tree::test_executable()
     gethostname(hostname, 1023);
 
     progpath = epath;
-    epath = epath+"fasttree >/dev/null 2>/dev/null";
+    epath = epath+"fasttree </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
     if(WEXITSTATUS(status) == 0)
         return true;
@@ -90,7 +90,7 @@ bool FastTree_tree::test_executable()
         return true;
 
     progpath = "";
-    status = system("fasttree >/dev/null 2>/dev/null");
+    status = system("fasttree </dev/null >/dev/null 2>/dev/null");
 
     if(WEXITSTATUS(status) == 1 && strcmp(hostname, "wasabi2")==0)
         return true;

--- a/src/fasttree_tree.cpp
+++ b/src/fasttree_tree.cpp
@@ -50,7 +50,7 @@ bool FastTree_tree::test_executable()
     if (epath.find("/")!=std::string::npos)
         epath = epath.substr(0,epath.rfind("/")+1);
     progpath = epath;
-    epath = epath+"fasttree </dev/null >/dev/null 2>/dev/null";
+    epath = epath+fasttreeexec+" -help </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     return WEXITSTATUS(status) == 0;
@@ -98,13 +98,13 @@ bool FastTree_tree::test_executable()
     // stdin stays redirected: harmless here since `-help` returns before
     // reading input, and it keeps every probe in this file consistent.
     progpath = epath;
-    epath = epath+"fasttree -help </dev/null >/dev/null 2>/dev/null";
+    epath = epath+fasttreeexec+" -help </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
     if(WEXITSTATUS(status) == 0)
         return true;
 
     progpath = "";
-    status = system("fasttree -help </dev/null >/dev/null 2>/dev/null");
+    status = system((fasttreeexec+" -help </dev/null >/dev/null 2>/dev/null").c_str());
 
     return WEXITSTATUS(status) == 0;
 
@@ -142,7 +142,7 @@ string FastTree_tree::infer_phylogeny(std::vector<string> *names,std::vector<str
     f_output.close();
 
     stringstream command;
-    command << progpath<<"fasttree -quiet -nopr -nosupport ";
+    command << progpath<<fasttreeexec<<" -quiet -nopr -nosupport ";
     if(is_protein)
         command << f_name.str() << " 2>/dev/null";
     else

--- a/src/mafft_alignment.cpp
+++ b/src/mafft_alignment.cpp
@@ -27,7 +27,7 @@ bool Mafft_alignment::test_executable()
     if (epath.find("/")!=std::string::npos)
         epath = epath.substr(0,epath.rfind("/")+1);
     mafftpath = epath;
-    epath = epath+"sh.exe "+epath+"mafft -h >/dev/null 2>/dev/null";
+    epath = epath+"sh.exe "+epath+"mafft -h </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
     return WEXITSTATUS(status) == 1;
 
@@ -53,14 +53,14 @@ bool Mafft_alignment::test_executable()
     #endif
 
     mafftpath = epath;
-    epath = epath+"mafft -h >/dev/null 2>/dev/null";
+    epath = epath+"mafft -h </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     if(WEXITSTATUS(status) == 1)
         return true;
 
     mafftpath = "";
-    status = system("mafft -h >/dev/null 2>/dev/null");
+    status = system("mafft -h </dev/null >/dev/null 2>/dev/null");
 
     return WEXITSTATUS(status) == 1;
 

--- a/src/prank.cpp
+++ b/src/prank.cpp
@@ -770,6 +770,23 @@ void readArguments(int argc, char *argv[])
                 FASTTREE = false;
             }
 
+            // name or path of the FastTree executable
+            //
+            // Upstream ships FastTree, FastTreeMP and FastTreeUPGMA; none of
+            // them is called "fasttree", so the hard-coded default finds a
+            // binary only where a distribution has added that name. Naming it
+            // is also the only way to choose between them, and that is a real
+            // choice: FastTreeMP is the multithreaded build, while
+            // FastTreeUPGMA computes UPGMA rather than approximately-ML trees.
+            //
+            // Tested before it is used, so a bad value falls back to prank's
+            // own guide tree exactly as a missing FastTree does.
+            else if (s.substr(0,10)=="-fasttree=")
+            {
+                fasttreeexec = string(argv[i]).substr(10);
+                FASTTREE = true;
+            }
+
             // use FastTree for guidetree computation
             else if (s=="-raxmlrebl")
             {
@@ -856,6 +873,7 @@ void printHelp(bool complete)
         cout<<"  -raxmlrebl [recompute branch lengths for prealigned data]"<<endl;
         cout<<"  -nomafft [no MAFFT initial alignment]"<<endl;
         cout<<"  -nofasttree [no FastTree guidetree]"<<endl;
+        cout<<"  -fasttree=name [FastTree executable; e.g. FastTree or FastTreeMP]"<<endl;
         cout<<"  -noanchors [no Exonerate anchoring]"<<endl;
         cout<<"  -nomlanc [no RAxML ancestors]"<<endl;
         cout<<"  -scoremafft [score also MAFFT alignment]"<<endl;

--- a/src/prank.h
+++ b/src/prank.h
@@ -57,6 +57,17 @@ string tempdir = "";
 string mafftpath = "";
 string exoneratepath = "";
 
+// The FastTree executable to look for and run. A NAME resolved through PATH,
+// or an absolute path. Not the same kind of thing as mafftpath/exoneratepath
+// above, which are directory prefixes this code discovers for itself.
+//
+// It has to be settable because upstream distributes FastTree, FastTreeMP and
+// FastTreeUPGMA, and none of those is spelled "fasttree" -- some distributions
+// add a lowercase name, which is the only reason the hard-coded default finds
+// anything. FastTreeUPGMA also builds UPGMA trees rather than approximately-ML
+// ones, so which binary is used is a modelling choice and cannot be guessed.
+string fasttreeexec = "fasttree";
+
 // structure model file
 string hmmname = "";
 HMModel *hmm;

--- a/src/raxmlancestors.cpp
+++ b/src/raxmlancestors.cpp
@@ -52,7 +52,7 @@ bool RaxmlAncestors::testExecutable()
     if (epath.find("/")!=std::string::npos)
         epath = epath.substr(0,epath.rfind("/")+1);
     bppdistpath = epath;
-    epath = epath+"raxml -h >/dev/null 2>/dev/null";
+    epath = epath+"raxml -h </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     return WEXITSTATUS(status) == 0;
@@ -79,7 +79,7 @@ bool RaxmlAncestors::testExecutable()
     #endif
 
     raxmlpath = epath;
-    epath = epath+"raxml -h >/dev/null 2>/dev/null";
+    epath = epath+"raxml -h </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
 
@@ -87,7 +87,7 @@ bool RaxmlAncestors::testExecutable()
         return true;
 
     raxmlpath = "";
-    status = system("raxml -h >/dev/null 2>/dev/null");
+    status = system("raxml -h </dev/null >/dev/null 2>/dev/null");
 
 
     return WEXITSTATUS(status) == 0;

--- a/src/raxmlrebl.cpp
+++ b/src/raxmlrebl.cpp
@@ -53,7 +53,7 @@ bool RaxmlRebl::testExecutable()
     if (epath.find("/")!=std::string::npos)
         epath = epath.substr(0,epath.rfind("/")+1);
     bppdistpath = epath;
-    epath = epath+"raxml -h >/dev/null 2>/dev/null";
+    epath = epath+"raxml -h </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
     return WEXITSTATUS(status) == 0;
@@ -80,7 +80,7 @@ bool RaxmlRebl::testExecutable()
     #endif
 
     raxmlpath = epath;
-    epath = epath+"raxml -h >/dev/null 2>/dev/null";
+    epath = epath+"raxml -h </dev/null >/dev/null 2>/dev/null";
     int status = system(epath.c_str());
 
 
@@ -88,7 +88,7 @@ bool RaxmlRebl::testExecutable()
         return true;
 
     raxmlpath = "";
-    status = system("raxml -h >/dev/null 2>/dev/null");
+    status = system("raxml -h </dev/null >/dev/null 2>/dev/null");
 
 
     return WEXITSTATUS(status) == 0;


### PR DESCRIPTION
`FastTree_tree::test_executable()` has three independent defects. Any one of
them alone makes FastTree unusable; together they make the failure silent.

## 1. The probe inherits stdin, so it can block forever

The probe runs

```cpp
system("fasttree >/dev/null 2>/dev/null");
```

`FastTree`'s own usage text documents `FastTree < alignment > tree` — reading
the alignment from **standard input** is a supported mode. So invoked with no
arguments and an inherited stdin, FastTree waits for an alignment that never
arrives, and `system()` never returns.

Whether it hangs depends entirely on what stdin happens to be. From a
terminal, or under a scheduler that leaves stdin open, prank stops dead with
no output and no error. Redirecting `</dev/null` gives FastTree immediate EOF.

The same pattern is in the other helper probes in this file and its
neighbours, so they are redirected too.

## 2. FastTree is undetectable except on one hard-coded host

Having survived the probe, the result is tested with

```cpp
if(WEXITSTATUS(status) == 0)
    return true;
```

FastTree run with no arguments prints its usage and exits **1**, so that test
can never succeed for it. The two clauses that followed accepted the real
status:

```cpp
if(WEXITSTATUS(status) == 1 && strcmp(hostname, "wasabi2")==0)
    return true;
```

— but only when `gethostname()` returns `wasabi2`. On every other machine
`test_executable()` returns false, prank silently falls back to its own guide
tree, and both probe processes are still spawned on every invocation.

Probing with `-help` fixes this without changing what "present" means.
`-help` is documented ("run FastTree without any arguments or with the -help
option") and exits 0, so the existing `== 0` predicate becomes correct and the
hostname special case is no longer needed. The `hostname` buffer and its
`gethostname()` call go with it.

## 3. The executable name is hard-coded, and it is not a name FastTree ships

Both the probe and the run hard-code `fasttree`. Upstream distributes
`FastTree`, `FastTreeMP` and `FastTreeUPGMA` — **none** of them spelled that
way. Some distributions add a lowercase name or symlink, which is the only
reason the hard-coded default finds anything at all. On a host with a stock
FastTree install, detection fails on the *name*, before the exit status is
ever consulted; so fixing (2) is necessary but not sufficient.

This adds `string fasttreeexec`, defaulting to `"fasttree"` so nothing changes
for anyone who is working today, and

```
-fasttree=name    FastTree executable; e.g. FastTree or FastTreeMP
```

which takes a name to resolve through `PATH`, or an absolute path.

Naming it is also the only way to *choose*, and the choice is a real one:
`FastTreeMP` is the OpenMP build, while `FastTreeUPGMA` computes UPGMA rather
than approximately-ML trees. Picking between those by sniffing the filesystem
would be guessing at a modelling decision, so it is left to the user.

All four sites use the variable, `infer_phylogeny()` included — detecting
`FastTreeMP` and then running `fasttree` would be worse than detecting
nothing. The value goes through the same `test_executable()` as before, so a
bad one falls back to prank's own guide tree exactly as a missing FastTree
does.

## Measured

GNU/Linux, FastTree 2.1.11 and 2.2.0:

```sh
fasttree </dev/null >/dev/null 2>/dev/null        ; echo $?   # -> 1
fasttree -help </dev/null >/dev/null 2>/dev/null  ; echo $?   # -> 0
```

(the `-help` figure measured on 2.1.11; `-help` is documented in 2.2.0's own
usage output.)

The option, against a wrapper that logs its argv and delegates to the real
binary:

```
prank -d=four.fa -o=out -F -once -fasttree=MyFastTree
  -> MYFT -help                                     (probe, prank's own dir)
     MYFT -help                                     (probe, PATH)
     MYFT -quiet -nopr -nosupport -nt <tmp>/d*.fas  (the actual run)
```

and the converse — lowercase `fasttree` shadowed as absent, no option given —
gives 0 invocations, prank falls back to its own guide tree and exits 0. That
is the situation today on any host carrying only the capitalised binaries.

## Two things worth calling out

**This is a behaviour change for users who have FastTree installed.** They
will now get a FastTree guide tree where they previously got prank's own,
because detection has never worked for them. That is presumably the intent of
the code, but it is not merely a cleanup, so it is stated here rather than
buried.

**It cannot regress a working setup.** A FastTree whose `-help` did not exit 0
would read as absent — which is exactly today's behaviour everywhere except
that one host. The new option defaults to the old hard-coded name, so a build
that finds FastTree today still finds the same one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
