### PR TITLE
fix: keep the terminal stop codon's column instead of dropping it

### DIFF
--- a/src/terminalsequence.cpp
+++ b/src/terminalsequence.cpp
@@ -85,7 +85,7 @@ TerminalSequence::TerminalSequence(string* s)
         codons.insert(make_pair("---",sAlpha));
 
 
-        bool stop_removed = false;
+        bool stop_masked = false;
 
         string S;
         for (int i=0; i<(int)s->length(); i++)
@@ -103,21 +103,34 @@ TerminalSequence::TerminalSequence(string* s)
                 charseq += S.substr(i,3);
             else if (S.substr(i,3)=="---" || S.substr(i,3)=="...")
                 ;
-            else if(i+3<S.length() || PREALIGNED)
-            {
-                charseq += "NNN";
-            }
             else
             {
-//                cout<<"removing: "<<S.substr(i,3)<<endl;
-                stop_removed = true;
+                // An unknown codon -- which includes every STOP codon, since
+                // the codon alphabet is 61-state and stops are not in it.
+                //
+                // Mid-sequence these were already masked as NNN, preserving
+                // the column so a caller can restore the real bases.  A
+                // TERMINAL one was DROPPED instead, silently shortening the
+                // sequence by three: a 3822 nt CDS ending in TAA came back as
+                // 3819 ending ...CATTACACA, and the caller had no column left
+                // to restore into.  Downstream that reads as "the stop codon
+                // was lost" rather than "the model cannot score it".
+                //
+                // Mask it like any other unknown codon.  The alignment is
+                // unaffected -- NNN is what the model already scores for the
+                // mid-sequence case -- but the length is now preserved, so the
+                // terminal stop stays addressable.  It is still reported at
+                // NOISE>0 below, as a masking rather than a removal.
+                charseq += "NNN";
+                if(!(i+3<(int)S.length() || PREALIGNED))
+                    stop_masked = true;
             }
         }
 
         seqLength = realLength = charseq.size()/3;
 
-        if(NOISE>0 && stop_removed)
-            cout<<"Note: stop codon was removed\n";
+        if(NOISE>0 && stop_masked)
+            cout<<"Note: terminal stop codon was masked as 'NNN'\n";
 
         if(NOISE>0 && gaps_removed)
             cout<<"Note: gaps were removed\n";


### PR DESCRIPTION
The codon alphabet is 61-state, so every stop codon is "unknown" to it.
`TerminalSequence` handled that inconsistently depending on **position**:

```c
else if(i+3<S.length() || PREALIGNED)
    charseq += "NNN";        // mid-sequence: masked, column preserved
else
    stop_removed = true;     // terminal: dropped, column gone
```

Mid-sequence an unknown codon becomes `NNN` and the caller keeps a column it
can restore the real bases into. A terminal one was discarded instead, silently
shortening the sequence by three: an N-codon CDS whose last codon is a stop
comes back with N-1 codons, for every sequence in the input alike.

Downstream that is indistinguishable from "the aligner lost the stop codon",
and it cannot be repaired by the caller, because there is no longer a column to
repair. A pipeline that reports a query's terminal stop as absent, or that
compares a result three nucleotides shorter than the reference it was aligned
against, is reading an artefact of this branch rather than a property of the
sequences.

### The change

Mask it like any other unknown codon. The alignment itself is unchanged — `NNN`
is already what the model scores for the mid-sequence case — but the length is
preserved and the terminal stop stays addressable.

The `NOISE>0` note is corrected with it: it read `"stop codon was removed"`,
which after this change would be false, and the local flag is renamed to match.
The sibling message this now parallels is `translatesequences.cpp`'s existing
`"Warning: Unknown codons replaced with 'NNN'."`

### Measured

Synthetic 60 nt two-sequence CDS ending in `TAA`, patched vs unpatched builds
of this tree:

| input | unpatched | patched |
|---|---|---|
| terminal stop | 57 nt | **60 nt** — first 57 columns byte-identical, appended column is `NNN` |
| no stop codon | 60 nt | byte-identical |
| mid-sequence stop | 60 nt | byte-identical |
| length % 3 != 0 | refused | refused identically (`codon sequence length is not multiple of three!`) |

So the only observable change is the intended one: a column that used to
disappear now survives, masked.
