### PR TITLE
Makefile: drop -I/usr/include, which breaks every build with a non-system compiler

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,11 @@ DEFINES       = -DNDEBUG
 CPPFLAGS     += $(DEFINES)
 CFLAGS       += -pipe -O3
 CXXFLAG      += -pipe -O3
-INCPATH       = -I. -I/usr/include
+# -I. only. An explicit -I/usr/include is redundant with any compiler's own
+# search path, and actively wrong when the compiler is not the system one:
+# it forces the SYSTEM libc headers into a build whose libstdc++ came from
+# elsewhere. prank links no external library, so it needs no -I but its own.
+INCPATH       = -I.
 LINK         ?= $(CXX)
 #LFLAGS       = -m64
 LIBS          = $(SUBLIBS)    


### PR DESCRIPTION
`src/Makefile` sets

```make
INCPATH       = -I. -I/usr/include
```

The explicit `-I/usr/include` is redundant when the compiler is the system one
— it already searches there — and **wrong when it is not**, because it forces
the system libc headers into a build whose libstdc++ comes from somewhere
else.

### Measured

On a Gentoo-prefix toolchain (its own `g++` 16, its own glibc), the build
fails on the first translation unit that includes `<cstdio>`:

```
In file included from <prefix>/lib/gcc/x86_64-pc-linux-gnu/16/include/g++-v16/cstdio:47,
                 from terminalnode.cpp:20:
/usr/include/stdio.h:205:27: error: 'L_tmpnam' was not declared in this scope
  205 | extern char *tmpnam (char[L_tmpnam]) __THROW __wur;
/usr/include/stdio.h:210:33: error: 'L_tmpnam' was not declared in this scope
  210 | extern char *tmpnam_r (char __s[L_tmpnam]) __THROW __wur;
```

— the prefix's `<cstdio>` pulling in the *system's* `<stdio.h>`, whose `bits/`
headers it does not match. All six units attempted in the first parallel wave
failed; the build cannot proceed. Passing `INCPATH="-I."` by hand fixes it,
which is what identifies the cause.

The same applies to any cross-compiler, container SDK, conda/spack toolchain
or software-prefix installation. It stays invisible until the two header sets
happen to disagree, which is why it survives on ordinary systems.

### Why `-I.` is sufficient

prank links no external library: `LIBS = $(SUBLIBS)` with `SUBLIBS` never set,
and `LFLAGS` commented out. So it needs no include path but its own source
directory, and the compiler supplies every system header from its own
consistent set.

### It cannot change a build that already works

Built twice from this tree on a system toolchain, `make clean` between — once
with `-I. -I/usr/include`, once with `-I.`. The resulting binaries are
**byte-identical**:

```
7171640a87fd75379dbccf74b5201dc43975cfb303bcb0e403daf83706ad5acb  prank (with -I/usr/include)
7171640a87fd75379dbccf74b5201dc43975cfb303bcb0e403daf83706ad5acb  prank (with -I. only)
```

So this removes a failure mode without altering the output of any build that
currently succeeds. Verified separately that the prefix toolchain then
compiles and links.

### Note on overlap

This touches line 13, immediately below the `CXXFLAG`/`CXXFLAGS` line that
#31 fixes. The two are independent, but if #31 is merged first this will need
a one-line rebase (or vice versa) — happy to do that whenever suits.

Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
